### PR TITLE
Feature/st00005 lead source

### DIFF
--- a/deployment/ST00005-Lead-Source/package.xml
+++ b/deployment/ST00005-Lead-Source/package.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+	<types>
+		<members>Opportunity-Lightning Product Order</members>
+		<name>Layout</name>
+	</types>
+	<types>
+		<members>Global_Growth_Base_Permission_Set</members>
+		<name>PermissionSet</name>
+	</types>
+	<version>60.0</version>
+</Package>

--- a/force-app/main/default/layouts/Opportunity-Lightning Product Order.layout-meta.xml
+++ b/force-app/main/default/layouts/Opportunity-Lightning Product Order.layout-meta.xml
@@ -40,6 +40,10 @@
                 <behavior>Required</behavior>
                 <field>CurrencyIsoCode</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>LeadSource</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>

--- a/force-app/main/default/permissionsets/Global_Growth_Base_Permission_Set.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Global_Growth_Base_Permission_Set.permissionset-meta.xml
@@ -22,7 +22,17 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Lead.LeadSource</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Lead.Previously_Existing_Contact__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Opportunity.LeadSource</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>


### PR DESCRIPTION
- Add read/edit permission for the LeadSource field to the global growth perm set
- Add the LeadSource field to Lightning Product Order page layout (default layout used by prosci growth team app)
- LeadSource field already present on the Enterprise Engagement layout