### PR TITLE
Update deployment materials

### DIFF
--- a/deployment/st-00004-Lead-Routing/Country_Code_Info__mdt.csv
+++ b/deployment/st-00004-Lead-Routing/Country_Code_Info__mdt.csv
@@ -1,0 +1,245 @@
+Name,Country_Name__c,Queue_Family__c,Language__c
+AD,Andorra,Europe,English
+AE,United Arab Emirates,GAN,Arabic;English
+AF,Afghanistan,GAN,Pashto;Persian;Uzbek
+AG,Antigua and Barbuda,Canada,English;Spanish
+AI,Anguilla,Canada,English;Spanish
+AL,Albania,Europe,English
+AM,Armenia,GAN,Armenian
+AN,Netherlands Antilles,Canada,English;Dutch;Papiamentu
+AO,Angola,GAN,Lingala;Portuguese
+AR,Argentina,LATAM,English;Spanish
+AS,American Samoa,US,English
+AT,Austria,Europe,German
+AU,Australia,ANZ,English
+AW,Aruba,Canada,Dutch;Spanish
+AZ,Azerbaijan,GAN,Azerbaijani;Azerbaijani
+BA,Bosnia and Herzegovina,Europe,English
+BB,Barbados,Canada,English;Spanish
+BD,Bangladesh,Singapore,Bangla;Chakma;English
+BE,Belgium,Europe,Dutch
+BF,Burkina Faso,GAN,French;Fulah
+BG,Bulgaria,Europe,English
+BH,Bahrain,GAN,Arabic
+BI,Burundi,GAN,English;French;Rundi
+BJ,Benin,GAN,French;Yoruba
+BM,Bermuda,Canada,English;Spanish
+BN,Brunei,Singapore,Malay;Malay
+BO,Bolivia,LATAM,Quechua;Spanish
+BR,Brazil,Brazil,English;Portuguese;Spanish
+BS,"Bahamas, The",Canada,English;Spanish
+BT,Bhutan,Singapore,Dzongkha
+BW,Botswana,GAN,English;Tswana
+BY,Belarus,Europe,English
+BZ,Belize,LATAM,English;Spanish
+CA,Canada,Canada,English;French;Inuktitut;Mohawk;Spanish
+CC,Cocos (Keeling) Islands,ANZ,English
+CF,Central African Republic,GAN,French;Lingala;Sango
+CG,"Congo, Republic of the",GAN,French;Lingala
+CH,Switzerland,Europe,German
+CI,Cote d'Ivoire,GAN,French
+CK,Cook Islands,ANZ,English
+CL,Chile,LATAM,English;Mapuche;Spanish
+CM,Cameroon,GAN,Aghem;Bafia;Basaa;Duala;English;Ewondo;French;Fulah;Kako;Kwasio;Meta?;Mundang;Ngiemboon;Ngomba;Yangben
+CN,China,Singapore,Cantonese;Chinese;Chinese;English;Sichuan Yi;Tibetan;Uyghur
+CO,Colombia,LATAM,English;Spanish
+CR,Costa Rica,LATAM,Spanish
+CU,Cuba,Canada,Spanish
+CV,Cape Verde,GAN,Kabuverdianu;Portuguese
+CX,Christmas Island,ANZ,English
+CY,Cyprus,Europe,English
+CZ,Czech Republic,Europe,English
+DE,Germany,Europe,German
+DJ,Djibouti,GAN,Arabic;French;Somali
+DK,Denmark,Europe,Danish
+DM,Dominica,Canada,English;Spanish
+DO,Dominican Republic,LATAM,Spanish
+DZ,Algeria,GAN,Arabic;French;Kabyle
+EC,Ecuador,LATAM,Quechua;Spanish
+EE,Estonia,Europe,English
+EG,Egypt,GAN,Arabic
+EH,Western Sahara,GAN,Arabic
+ER,Eritrea,GAN,Arabic;Blin;English;Geez;Tigre;Tigrinya
+ES,Spain,Europe,Spanish
+FI,Finland,Europe,Finnish
+FK,Falkland Islands (Islas Malvinas),Europe,English
+FO,Faroe Islands,Europe,English
+FR,France,Europe,French
+GA,Gabon,GAN,French
+GB,United Kingdom,Europe,English
+GD,Grenada,Canada,English;Spanish
+GF,French Guiana,LATAM,French;Spanish
+GG,Guernsey,Europe,English
+GI,Gibraltar,Europe,English
+GL,Greenland,Europe,Greenlandic
+GM,"Gambia, The",GAN,English;Fulah
+GN,Guinea,GAN,French;Fulah;Kpelle;N?Ko
+GP,Guadeloupe,Europe,French
+GR,Greece,Europe,English
+GT,Guatemala,LATAM,Spanish
+GU,Guam,US,English
+GW,Guinea-Bissau,GAN,Fulah;Portuguese
+GY,Guyana,LATAM,English;Spanish
+HN,Honduras,LATAM,Spanish
+HR,Croatia,Europe,English
+HT,Haiti,Canada,French;Spanish
+HU,Hungary,Europe,English
+ID,Indonesia,Singapore,English;Indonesian;Javanese
+IE,Ireland,Europe,English
+IL,Israel,GAN,Arabic;English;Hebrew
+IM,Isle of Man,GAN,English;Manx
+IN,India,Singapore,Assamese;Bangla;Bodo;Chakma;English;Gujarati;Hindi;Kannada;Kashmiri;Kashmiri;Kashmiri;Konkani;Malayalam;Manipuri;Manipuri;Marathi;Nepali;Odia;Punjabi;Sanskrit;Santali;Santali;Tamil;Telugu;Tibetan;Urdu;Urdu;Urdu
+IQ,Iraq,GAN,Arabic;Kurdish;Sorani;Northern Luri;Syriac
+IR,Iran,GAN,Kurdish;Sorani;Mazanderani;Northern Luri;Persian
+IS,Iceland,Europe,Icelandic
+IT,Italy,Europe,Italian
+JE,Jersey,Europe,English
+JM,Jamaica,Canada,English
+JO,Jordan,GAN,Arabic
+JP,Japan,Singapore,English;Japanese
+KE,Kenya,GAN,Embu;English;Gusii;Kalenjin;Kamba;Kikuyu;Luo;Luyia;Masai;Meru;Oromo;Samburu;Somali;Swahili;Taita;Teso
+KG,Kyrgyzstan,GAN,Kyrgyz;Russian
+KH,Cambodia,Singapore,Khmer
+KI,Kiribati,GAN,English
+KM,Comoros,GAN,Arabic;French
+KN,Saint Kitts and Nevis,Canada,English;Spanish
+KP,"Korea, North",GAN,Korean
+KR,"Korea, South",Singapore,English;Korean
+KW,Kuwait,GAN,Arabic
+KY,Cayman Islands,Canada,English;Spanish
+KZ,Kazakhstan,GAN,Kazakh;Russian
+LA,Laos,GAN,Lao
+LB,Lebanon,GAN,Arabic
+LC,Saint Lucia,Canada,English;Spanish
+LI,Liechtenstein,Europe,German
+LK,Sri Lanka,Singapore,Sinhala;Tamil
+LR,Liberia,GAN,English;Fulah;Kpelle;Vai;Vai
+LS,Lesotho,GAN,English;Southern Sotho
+LT,Lithuania,Europe,English
+LU,Luxembourg,Europe,English
+LV,Latvia,Europe,English
+LY,Libya,GAN,Arabic
+MA,Morocco,GAN,Arabic;Central Atlas Tamazight;French;Standard Moroccan Tamazight;Tachelhit;Tachelhit
+MC,Monaco,Europe,French
+MD,Moldova,Europe,English
+MG,Madagascar,GAN,English;French;Malagasy
+MH,Marshall Islands,GAN,English
+MK,Macedonia,Europe,English
+ML,Mali,GAN,Bambara;French;Koyra Chiini;Koyraboro Senni
+MM,Myanmar (Burma),GAN,Burmese;English
+MN,Mongolia,GAN,Mongolian
+MP,Northern Mariana Islands,GAN,English
+MQ,Martinique,Europe,French
+MR,Mauritania,GAN,Arabic;French;Fulah
+MS,Montserrat,GAN,English;Spanish
+MT,Malta,Europe,English
+MU,Mauritius,GAN,English;French;Morisyen
+MV,Maldives,GAN,Dhivehi;English
+MW,Malawi,GAN,English;Nyanja
+MX,Mexico,LATAM,English;Spanish
+MY,Malaysia,Singapore,English;Malay;Malay;Tamil
+MZ,Mozambique,GAN,Makhuwa-Meetto;Portuguese;Sena
+NA,Namibia,GAN,Afrikaans;English;Nama
+NC,New Caledonia,GAN,French
+NE,Niger,GAN,French;Fulah;Hausa;Tasawaq;Zarma
+NF,Norfolk Island,GAN,English
+NG,Nigeria,GAN,English;Fulah;Hausa;Igbo;Jju;Tyap;Yoruba
+NI,Nicaragua,LATAM,Spanish
+NL,Netherlands,Europe,Dutch
+NO,Norway,Europe,Norwegian
+NP,Nepal,GAN,Nepali
+NR,Nauru,GAN,English
+NU,Niue,GAN,English
+NZ,New Zealand,ANZ,English;Maori
+OM,Oman,GAN,Arabic
+PA,Panama,LATAM,Spanish
+PE,Peru,LATAM,Quechua;Spanish
+PF,French Polynesia,GAN,French
+PG,Papua New Guinea,ANZ,English
+PH,Philippines,Singapore,Cebuano;English;Filipino;Spanish
+PK,Pakistan,Singapore,English;Pashto;Punjabi;Punjabi;Sindhi;Urdu;Urdu;Urdu
+PL,Poland,Europe,English
+PM,Saint Pierre and Miquelon,GAN,French
+PN,Pitcairn Islands,GAN,English
+PR,Puerto Rico,US,English;Spanish
+PS,Palestine,GAN,Arabic
+PT,Portugal,Europe,English
+PW,Palau,GAN,English
+PY,Paraguay,LATAM,Guarani;Spanish
+QA,Qatar,GAN,Arabic
+RE,Reunion,Europe,French
+RO,Romania,Europe,English
+RS,Serbia and Montenegro,GAN,Montenegrin;Serbian
+RU,Russia,Europe,English
+RW,Rwanda,GAN,English;French;Kinyarwanda
+SA,Saudi Arabia,GAN,Arabic;English
+SB,Solomon Islands,GAN,English
+SC,Seychelles,GAN,English;French
+SD,Sudan,GAN,Arabic;English
+SE,Sweden,Europe,Swedish
+SG,Singapore,Singapore,Chinese;English;Malay;Tamil
+SI,Slovenia,Europe,English
+SJ,Svalbard and Jan Mayen,GAN,Norwegian
+SK,Slovakia,Europe,English
+SL,Sierra Leone,GAN,English;Fulah
+SM,San Marino,Europe,Italian
+SN,Senegal,GAN,French;Fulah;Jola-Fonyi;Wolof
+SO,Somalia,GAN,Arabic;Somali
+SR,Suriname,GAN,Dutch;Spanish
+ST,Sao Tome and Principe,GAN,Portuguese
+SV,El Salvador,LATAM,Spanish
+SY,Syria,GAN,Arabic;French;Syriac
+SZ,Swaziland,GAN,Swati;English
+TC,Turks and Caicos Islands,Canada,English;Spanish
+TD,Chad,GAN,Arabic;French
+TG,Togo,GAN,Ewe;French
+TH,Thailand,Singapore,English;Thai
+TJ,Tajikistan,GAN,Tajik
+TK,Tokelau,GAN,English
+TM,Turkmenistan,GAN,Turkmen
+TN,Tunisia,GAN,Arabic;French
+TO,Tonga,GAN,English;Tongan
+TR,Turkey,GAN,English;Kurdish;Turkish
+TT,Trinidad and Tobago,Canada,English;Spanish
+TV,Tuvalu,GAN,English
+TW,Taiwan,Singapore,Chinese;English;Taroko
+TZ,Tanzania,GAN,Asu;Bena;English;Langi;Machame;Makonde;Masai;Rombo;Rwa;Sangu;Shambala;Swahili;Vunjo
+Test,Test,ANZ,Test
+UA,Ukraine,Europe,English
+UG,Uganda,GAN,Chiga;English;Ganda;Nyankole;Soga;Swahili;Teso
+US,United States,US,Cherokee;English (United States);English;Hawaiian;Lakota;Spanish
+UY,Uruguay,LATAM,Spanish
+UZ,Uzbekistan,GAN,Uzbek;Uzbek
+VA,Holy See (Vatican City),GAN,Italian;Latin
+VC,Saint Vincent and the Grenadines,GAN,English
+VE,Venezuela,LATAM,Spanish
+VG,British Virgin Islands,GAN,English;Spanish
+VI,Virgin Islands,US,English;Spanish
+VN,Vietnam,Singapore,Vietnamese
+VU,Vanuatu,Europe,English
+WF,Wallis and Futuna,GAN,French
+WS,Western Samoa,GAN,Samoan;English
+YE,Yemen,GAN,Arabic
+YT,Mayotte,GAN,French
+ZA,South Africa,GAN,Afrikaans;English;Northern Sotho;South Ndebele;Southern Sotho;Swati;Tsonga;Tswana;Venda;Xhosa;Zulu
+ZM,Zambia,GAN,Bemba;English
+ZW,Zimbabwe,GAN,English;North Ndebele;Shona
+AQ,Antarctica,GAN,None
+AX,Åland Islands,Europe,Swedish
+BL,Saint Barthélemy,Canada,French
+BV,Bouvet Island,Europe,Norwegian
+CD,Democratic Republic of the Congo,GAN,French
+CW,Curaçao,Canada,"Dutch, Papiamento, English"
+GS,South Georgia and the South Sandwich Islands,Europe,English
+HK,Hong Kong,Singapore,"Chinese, English"
+HM,Heard Island and McDonald Islands,GAN,English
+IO,British Indian Ocean Territory,GAN,English
+MF,Saint Martin (French part),Canada,French
+MO,Macau,Singapore,"Chinese, Portuguese"
+SH,"Saint Helena, Ascension and Tristan da Cunha",GAN,English
+SS,South Sudan,GAN,English
+SX,Sint Maarten,GAN,"Dutch, English"
+TF,French Southern and Antarctic Lands,Europe,French
+TL,Timor-Leste (East Timor),GAN,"Portuguese, Tetum"
+UM,United States Minor Outlying Islands,GAN,English
+XK,Kosovo,Europe,"Albanian, Serbian"

--- a/deployment/st-00004-Lead-Routing/steps.md
+++ b/deployment/st-00004-Lead-Routing/steps.md
@@ -3,12 +3,13 @@
 1. Migrate MDT records using CSV file
     - File name: Country_Code_Info__mdt.csv
     - CSF CLI command (enter from SF project terminal VS Code): 
-    ⋅⋅⋅*sf cmdt generate records --csv [folder/]Country_Code_Info__mdt.csv --type-name Country_Code_Info__mdt*
-    *Creates MDT records locally; developer will still need to deploy them to target org*
+        - *sf cmdt generate records --csv deployment/Country_Code_Info__mdt.csv --type-name Country_Code_Info__mdt*
+    **Creates MDT records locally; developer will still need to deploy them to target org*
 2. Activate Lead - Assign Country Code Info flow
-3. Ensure users with [permission set] permissions can access the Lead - Assign Country Code Info flow
+3. Update Growth Base Permission Set
+    - Grant access the Lead - Assign Country Code Info flow
+    - Update FLS for the following:
+        - Lead.Country_Name__c
+        - Lead.Languages__c
+        - Lead.Queue_Family__c
 4. Ensure Prosci Global Lead Assignments lead assignment rule(s) is active
-5. Grant Edit/Visible access for the following fields and permissions:
-    - Lead.Country_Name__c
-    - Lead.Languages__c
-    - Lead.Queue_Family__c


### PR DESCRIPTION
_FOR NEXT WEEK (TUES, MAY 27)_
* Deployment materials overwritten in merge to Slalom-Release-1:
    * Restores CSV file of Country Code Info records to insert
    * Restores latest post-deployment steps for Lead Routing