### PR TITLE
St00014 related training events prefill

### DIFF
--- a/force-app/main/default/flexipages/Deal_Support_Process_Page_Single_Related_Lists.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Deal_Support_Process_Page_Single_Related_Lists.flexipage-meta.xml
@@ -123,6 +123,29 @@
                     <name>uiBehavior</name>
                     <value>none</value>
                 </fieldInstanceProperties>
+                <fieldItem>Record.Closed_Reason__c</fieldItem>
+                <identifier>RecordClosed_Reason_cField</identifier>
+                <visibilityRule>
+                    <booleanFilter>1 OR 2</booleanFilter>
+                    <criteria>
+                        <leftValue>{!Record.Status__c}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>Done - Successful</rightValue>
+                    </criteria>
+                    <criteria>
+                        <leftValue>{!Record.Status__c}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>Closed - Lost</rightValue>
+                    </criteria>
+                </visibilityRule>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
                 <fieldItem>Record.Program_Title__c</fieldItem>
                 <identifier>RecordProgram_Title_cField</identifier>
             </fieldInstance>

--- a/force-app/main/default/quickActions/Deal_Support_Process__c.New_Event.quickAction-meta.xml
+++ b/force-app/main/default/quickActions/Deal_Support_Process__c.New_Event.quickAction-meta.xml
@@ -18,12 +18,92 @@
         <formula>Deal_Support_Process__c.Location__c</formula>
     </fieldOverrides>
     <fieldOverrides>
+        <field>Name</field>
+        <formula>Deal_Support_Process__c.AccountId__r.Name + &apos; (pending) | &apos;
+
+/* start month */
++ CASE(MONTH(Deal_Support_Process__c.Requested_Training_Start_Date__c),
+1, &quot;January &quot;,
+2, &quot;February &quot;,
+3, &quot;March &quot;, 
+4, &quot;April &quot;, 
+5, &quot;May &quot;, 
+6, &quot;June &quot;,
+7, &quot;July &quot;,
+8, &quot;August &quot;,
+9, &quot;September &quot;,
+10, &quot;October &quot;,
+11, &quot;November &quot;,
+12, &quot;December &quot;,
+&quot;&quot;)
+
+/* start day */
++ TEXT(DAY(Deal_Support_Process__c.Requested_Training_Start_Date__c))
+
+/* if the start and end year are different show the start year for date range */
++ IF(
+  YEAR(Deal_Support_Process__c.Requested_Training_Start_Date__c) = 
+  YEAR(Deal_Support_Process__c.Requested_Training_End_Date__c),
+  &apos;&apos;,
+  &apos;, &apos; + TEXT(YEAR(Deal_Support_Process__c.Requested_Training_Start_Date__c))
+)
+
+/* if the start and end day are the same date we don&apos;t show dash for date range */
++ IF(
+  AND(
+    DAYOFYEAR(Deal_Support_Process__c.Requested_Training_Start_Date__c) = 
+    DAYOFYEAR(Deal_Support_Process__c.Requested_Training_End_Date__c),
+
+    YEAR(Deal_Support_Process__c.Requested_Training_Start_Date__c) = 
+    YEAR(Deal_Support_Process__c.Requested_Training_End_Date__c)
+  ),
+ &apos;&apos;,
+ &apos; - &apos;
+)
+
+/* if the start end month and year are same don&apos;t show the end month for date range */
++ IF(
+  AND(
+    Month(Deal_Support_Process__c.Requested_Training_Start_Date__c) = 
+    Month(Deal_Support_Process__c.Requested_Training_End_Date__c),
+
+    YEAR(Deal_Support_Process__c.Requested_Training_Start_Date__c) = 
+    YEAR(Deal_Support_Process__c.Requested_Training_End_Date__c)
+  ),
+  &apos;&apos;,
+  CASE(MONTH(Deal_Support_Process__c.Requested_Training_End_Date__c),
+  1, &quot;January &quot;,
+  2, &quot;February &quot;,
+  3, &quot;March &quot;, 
+  4, &quot;April &quot;, 
+  5, &quot;May &quot;, 
+  6, &quot;June &quot;,
+  7, &quot;July &quot;,
+  8, &quot;August &quot;,
+  9, &quot;September &quot;,
+  10, &quot;October &quot;,
+  11, &quot;November &quot;,
+  12, &quot;December &quot;,
+  &quot;&quot;)
+)
+
+/* end day */
++ TEXT(DAY(Deal_Support_Process__c.Requested_Training_End_Date__c))
+
+/* end year */
++ &apos;, &apos; + TEXT(YEAR(Deal_Support_Process__c.Requested_Training_End_Date__c))</formula>
+    </fieldOverrides>
+    <fieldOverrides>
         <field>Related_Opportunity__c</field>
         <formula>Deal_Support_Process__c.Opportunity__c</formula>
     </fieldOverrides>
     <fieldOverrides>
         <field>Start_Date__c</field>
         <formula>Deal_Support_Process__c.Requested_Training_Start_Date__c</formula>
+    </fieldOverrides>
+    <fieldOverrides>
+        <field>Status__c</field>
+        <literalValue>Pending</literalValue>
     </fieldOverrides>
     <fieldOverrides>
         <field>Title__c</field>
@@ -44,45 +124,19 @@
             </quickActionLayoutItems>
             <quickActionLayoutItems>
                 <emptySpace>false</emptySpace>
-                <field>Location__c</field>
-                <uiBehavior>Edit</uiBehavior>
-            </quickActionLayoutItems>
-            <quickActionLayoutItems>
-                <emptySpace>false</emptySpace>
-                <field>Start_Date__c</field>
-                <uiBehavior>Edit</uiBehavior>
-            </quickActionLayoutItems>
-            <quickActionLayoutItems>
-                <emptySpace>false</emptySpace>
-                <field>End_Date__c</field>
-                <uiBehavior>Edit</uiBehavior>
-            </quickActionLayoutItems>
-            <quickActionLayoutItems>
-                <emptySpace>false</emptySpace>
-                <field>VILT_Program__c</field>
+                <field>Training_Company__c</field>
                 <uiBehavior>Edit</uiBehavior>
             </quickActionLayoutItems>
         </quickActionLayoutColumns>
         <quickActionLayoutColumns>
             <quickActionLayoutItems>
-                <emptySpace>false</emptySpace>
-                <field>Title__c</field>
+                <emptySpace>true</emptySpace>
                 <uiBehavior>Edit</uiBehavior>
             </quickActionLayoutItems>
             <quickActionLayoutItems>
                 <emptySpace>false</emptySpace>
                 <field>Instructor_Type__c</field>
                 <uiBehavior>Required</uiBehavior>
-            </quickActionLayoutItems>
-            <quickActionLayoutItems>
-                <emptySpace>false</emptySpace>
-                <field>End_User_Company__c</field>
-                <uiBehavior>Edit</uiBehavior>
-            </quickActionLayoutItems>
-            <quickActionLayoutItems>
-                <emptySpace>false</emptySpace>
-                <field>Related_Opportunity__c</field>
-                <uiBehavior>Edit</uiBehavior>
             </quickActionLayoutItems>
         </quickActionLayoutColumns>
     </quickActionLayout>


### PR DESCRIPTION
- Adds the Closed Reason field to the DSP page layout after adding the new values, field renders under Status field when it detects the DSP status is set to "Closed - Lost" or "Done - Successful"
- Update the DSP Create Prosci Training Event quick action to fill values based on Mary's feedback, removed the fields that are prefilled by quick action to simplify