### PR TITLE
Feature/st 00030 generate dsp

### DIFF
--- a/deployment/st-00030-Generate-Deal-Support-Processes/package.xml
+++ b/deployment/st-00030-Generate-Deal-Support-Processes/package.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+	<version>60.0</version>
+</Package>

--- a/deployment/st-00030-Generate-Deal-Support-Processes/package.xml
+++ b/deployment/st-00030-Generate-Deal-Support-Processes/package.xml
@@ -1,4 +1,29 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
+	<types>
+		<members>Opportunity.Has_Deal_Support_Process__c</members>
+		<name>CustomField</name>
+	</types>
+	<types>
+		<members>Generate_Deal_Support_Process_Permission</members>
+		<name>CustomPermission</name>
+	</types>
+	<types>
+		<members>Opportunity_Record_Page_Advisory_Services_Single_Related_Lists1</members>
+		<members>Opportunity_Record_Page_Single_Related_Lists</members>
+		<name>FlexiPage</name>
+	</types>
+	<types>
+		<members>Opportunity_Generate_Deal_Support_Processes</members>
+		<name>Flow</name>
+	</types>
+	<types>
+		<members>Global_Growth_Base_Permission_Set</members>
+		<name>PermissionSet</name>
+	</types>
+	<types>
+		<members>Opportunity.Generate_Deal_Support_Process</members>
+		<name>WebLink</name>
+	</types>
 	<version>60.0</version>
 </Package>

--- a/deployment/st-00030-Generate-Deal-Support-Processes/steps.md
+++ b/deployment/st-00030-Generate-Deal-Support-Processes/steps.md
@@ -1,0 +1,2 @@
+# Post-Deployment Steps:
+

--- a/force-app/main/default/customPermissions/Generate_Deal_Support_Process_Permission.customPermission-meta.xml
+++ b/force-app/main/default/customPermissions/Generate_Deal_Support_Process_Permission.customPermission-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomPermission xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Permission to view/execute generate Deal Support Process record(s) from an Opportunity.</description>
+    <isLicensed>false</isLicensed>
+    <label>Generate Deal Support Process Permission</label>
+</CustomPermission>

--- a/force-app/main/default/flexipages/Opportunity_Record_Page_Advisory_Services_Single_Related_Lists1.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Opportunity_Record_Page_Advisory_Services_Single_Related_Lists1.flexipage-meta.xml
@@ -4,16 +4,93 @@
         <itemInstances>
             <componentInstance>
                 <componentInstanceProperties>
+                    <name>actionNames</name>
+                    <valueList>
+                        <valueListItems>
+                            <value>Global.NewTask</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>Global.LogACall</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>FeedItem.ContentPost</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>FeedItem.LinkPost</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>Clone</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>Edit</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>CustomButton.Opportunity.MA_MapIt_a0vi000000Bnnt8AAB</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>CustomButton.Opportunity.Add_Document</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>CustomButton.Opportunity.Select_Clause_Bundle</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>CustomButton.Opportunity.Generate_SOW</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>CustomButton.Opportunity.Send_for_Negotiation</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>CustomButton.Opportunity.View_Redlines</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>CustomButton.Opportunity.Send_Final_Negotiated_Contract_for_Signature</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>CustomButton.Opportunity.CongaSign_sendForSignature</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>ChangeRecordType</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>ChangeOwnerOne</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>Delete</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>CustomButton.Opportunity.Generate_Deal_Support_Process</value>
+                            <visibilityRule>
+                                <booleanFilter>1 AND 2 AND 3</booleanFilter>
+                                <criteria>
+                                    <leftValue>{!Record.Probability}</leftValue>
+                                    <operator>GE</operator>
+                                    <rightValue>50</rightValue>
+                                </criteria>
+                                <criteria>
+                                    <leftValue>{!$Permission.CustomPermission.Generate_Deal_Support_Process_Permission}</leftValue>
+                                    <operator>EQUAL</operator>
+                                    <rightValue>true</rightValue>
+                                </criteria>
+                                <criteria>
+                                    <leftValue>{!Record.Has_Deal_Support_Process__c}</leftValue>
+                                    <operator>EQUAL</operator>
+                                    <rightValue>false</rightValue>
+                                </criteria>
+                            </visibilityRule>
+                        </valueListItems>
+                    </valueList>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
                     <name>collapsed</name>
                     <value>false</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>enableActionsConfiguration</name>
-                    <value>false</value>
+                    <value>true</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>enableActionsInNative</name>
-                    <value>false</value>
+                    <value>true</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>hideChatterActions</name>

--- a/force-app/main/default/flexipages/Opportunity_Record_Page_Single_Related_Lists.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Opportunity_Record_Page_Single_Related_Lists.flexipage-meta.xml
@@ -4,16 +4,75 @@
         <itemInstances>
             <componentInstance>
                 <componentInstanceProperties>
+                    <name>actionNames</name>
+                    <valueList>
+                        <valueListItems>
+                            <value>Opportunity.Initiate_Contract_Agreement</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>CustomButton.Opportunity.CongaSign_sendForSignature</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>CustomButton.Opportunity.Send_Final_Negotiated_Contract_for_Signature</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>CustomButton.Opportunity.View_Redlines</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>Clone</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>Edit</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>CustomButton.Opportunity.Add_Document</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>ChangeRecordType</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>ChangeOwnerOne</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>Delete</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>DeepClone</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>CustomButton.Opportunity.Generate_Deal_Support_Process</value>
+                            <visibilityRule>
+                                <booleanFilter>1 AND 2 AND 3</booleanFilter>
+                                <criteria>
+                                    <leftValue>{!Record.Probability}</leftValue>
+                                    <operator>GE</operator>
+                                    <rightValue>50</rightValue>
+                                </criteria>
+                                <criteria>
+                                    <leftValue>{!$Permission.CustomPermission.Generate_Deal_Support_Process_Permission}</leftValue>
+                                    <operator>EQUAL</operator>
+                                    <rightValue>true</rightValue>
+                                </criteria>
+                                <criteria>
+                                    <leftValue>{!Record.Has_Deal_Support_Process__c}</leftValue>
+                                    <operator>EQUAL</operator>
+                                    <rightValue>false</rightValue>
+                                </criteria>
+                            </visibilityRule>
+                        </valueListItems>
+                    </valueList>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
                     <name>collapsed</name>
                     <value>false</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>enableActionsConfiguration</name>
-                    <value>false</value>
+                    <value>true</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>enableActionsInNative</name>
-                    <value>false</value>
+                    <value>true</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>hideChatterActions</name>

--- a/force-app/main/default/flows/Opportunity_Generate_Deal_Support_Processes.flow-meta.xml
+++ b/force-app/main/default/flows/Opportunity_Generate_Deal_Support_Processes.flow-meta.xml
@@ -1,0 +1,682 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Flow xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <assignments>
+        <description>Adds a Deal Support Process record to the collection of records of the same classification</description>
+        <name>Add_Deal_Support_Process_Record_to_Collection</name>
+        <label>Add Deal Support Process Record to Collection</label>
+        <locationX>1649</locationX>
+        <locationY>497</locationY>
+        <assignmentItems>
+            <assignToReference>dealSupportProcesses</assignToReference>
+            <operator>Add</operator>
+            <value>
+                <elementReference>dealSupportProcess</elementReference>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Iterate_through_Opportunity_Products</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
+        <description>Adds a Deal Support Process record, whose Record Type = Training, to the collection of records of the same classification</description>
+        <name>Add_Deal_Support_Process_Record_to_Collection_Training</name>
+        <label>Add Deal Support Process Record to Collection (Training)</label>
+        <locationX>2548</locationX>
+        <locationY>257</locationY>
+        <assignmentItems>
+            <assignToReference>dealSupportProcesses</assignToReference>
+            <operator>Add</operator>
+            <value>
+                <elementReference>dealSupportProcess</elementReference>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Increment_Training_Counter</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
+        <description>Assigns Advisory record type Id to its designated variable</description>
+        <name>Assign_Advisory</name>
+        <label>Assign Advisory</label>
+        <locationX>1082</locationX>
+        <locationY>564</locationY>
+        <assignmentItems>
+            <assignToReference>advisoryDSPId</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>Assign_Record_Type_Ids_to_Variables.Id</elementReference>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Assign_Record_Type_Ids_to_Variables</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
+        <description>Assigns Advisory Record Type Id to dspRecordType variable</description>
+        <name>Assign_Advisory_Record_Type</name>
+        <label>Assign Advisory Record Type</label>
+        <locationX>1758</locationX>
+        <locationY>370</locationY>
+        <assignmentItems>
+            <assignToReference>dspRecordType</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>advisoryDSPId</elementReference>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Assign_Deal_Support_Process_Fields</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
+        <description>Assigns values to Deal Support Process record</description>
+        <name>Assign_Deal_Support_Process_Fields</name>
+        <label>Assign Deal Support Process Fields</label>
+        <locationX>1873</locationX>
+        <locationY>498</locationY>
+        <assignmentItems>
+            <assignToReference>dealSupportProcess.Quantity__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>Iterate_through_Opportunity_Products.Quantity</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>dealSupportProcess.Price__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>Iterate_through_Opportunity_Products.UnitPrice</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>dealSupportProcess.Opportunity_Product__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>Iterate_through_Opportunity_Products.Id</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>dealSupportProcess.Name</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>Iterate_through_Opportunity_Products.Name</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>dealSupportProcess.RecordTypeId</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>dspRecordType</elementReference>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Add_Deal_Support_Process_Record_to_Collection</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
+        <description>Assigns values to Deal Support Process record where Record Type = Training</description>
+        <name>Assign_Deal_Support_Process_Fields_Training</name>
+        <label>Assign Deal Support Process Fields Training</label>
+        <locationX>2417</locationX>
+        <locationY>134</locationY>
+        <assignmentItems>
+            <assignToReference>dealSupportProcess.Quantity__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>Iterate_through_Opportunity_Products.Attendees_Per_Session__c</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>dealSupportProcess.Price__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>Iterate_through_Opportunity_Products.UnitPrice</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>dealSupportProcess.Opportunity_Product__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>Iterate_through_Opportunity_Products.Id</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>dealSupportProcess.Name</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>Iterate_through_Opportunity_Products.Name</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>dealSupportProcess.RecordTypeId</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>trainingDSPId</elementReference>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Add_Deal_Support_Process_Record_to_Collection_Training</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
+        <description>Assigns Licensing record type Id to its designated variable</description>
+        <name>Assign_Licensing</name>
+        <label>Assign Licensing</label>
+        <locationX>1208</locationX>
+        <locationY>570</locationY>
+        <assignmentItems>
+            <assignToReference>licensingDSPId</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>Assign_Record_Type_Ids_to_Variables.Id</elementReference>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Assign_Record_Type_Ids_to_Variables</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
+        <description>Assigns Licensing Record Type Id to dspRecordType variable</description>
+        <name>Assign_Licensing_Record_Type</name>
+        <label>Assign Licensing Record Type</label>
+        <locationX>1993</locationX>
+        <locationY>369</locationY>
+        <assignmentItems>
+            <assignToReference>dspRecordType</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>licensingDSPId</elementReference>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Assign_Deal_Support_Process_Fields</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
+        <description>Assigns Training record type Id to its designated variable</description>
+        <name>Assign_Training</name>
+        <label>Assign Training</label>
+        <locationX>1339</locationX>
+        <locationY>566</locationY>
+        <assignmentItems>
+            <assignToReference>trainingDSPId</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>Assign_Record_Type_Ids_to_Variables.Id</elementReference>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Assign_Record_Type_Ids_to_Variables</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
+        <description>Increments Training Counter by one for each Training session</description>
+        <name>Increment_Training_Counter</name>
+        <label>Increment Training Counter</label>
+        <locationX>2435</locationX>
+        <locationY>365</locationY>
+        <assignmentItems>
+            <assignToReference>trainingCounter</assignToReference>
+            <operator>Add</operator>
+            <value>
+                <numberValue>1.0</numberValue>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Check_Number_of_Trainings</targetReference>
+        </connector>
+    </assignments>
+    <decisions>
+        <description>Determines which record type should be assigned to which variable</description>
+        <name>Check_Deal_Support_Process_Name</name>
+        <label>Check Deal Support Process Name</label>
+        <locationX>1192</locationX>
+        <locationY>340</locationY>
+        <defaultConnector>
+            <targetReference>Assign_Record_Type_Ids_to_Variables</targetReference>
+        </defaultConnector>
+        <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>
+        <rules>
+            <name>Is_DSP_Advisory</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>Assign_Record_Type_Ids_to_Variables.Name</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <elementReference>advisoryDSPName</elementReference>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Assign_Advisory</targetReference>
+            </connector>
+            <label>Is DSP Advisory</label>
+        </rules>
+        <rules>
+            <name>Is_DSP_Licensing</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>Assign_Record_Type_Ids_to_Variables.Name</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <elementReference>licensingDSPName</elementReference>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Assign_Licensing</targetReference>
+            </connector>
+            <label>Is DSP Licensing</label>
+        </rules>
+        <rules>
+            <name>Is_DSP_Training</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>Assign_Record_Type_Ids_to_Variables.Name</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <elementReference>trainingDSPName</elementReference>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Assign_Training</targetReference>
+            </connector>
+            <label>Is DSP Training</label>
+        </rules>
+    </decisions>
+    <decisions>
+        <description>Counts the number of Training sessions purchased; determines how many Deal Support Process - Training records to create.</description>
+        <name>Check_Number_of_Trainings</name>
+        <label>Check Number of Trainings</label>
+        <locationX>2100</locationX>
+        <locationY>164</locationY>
+        <defaultConnector>
+            <targetReference>Iterate_through_Opportunity_Products</targetReference>
+        </defaultConnector>
+        <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>
+        <rules>
+            <name>Counter_Is_Less_Than_Number_of_Training_Sessions</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>trainingCounter</leftValueReference>
+                <operator>LessThan</operator>
+                <rightValue>
+                    <elementReference>Iterate_through_Opportunity_Products.Number_of_Sessions__c</elementReference>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Assign_Deal_Support_Process_Fields_Training</targetReference>
+            </connector>
+            <label>Counter Is Less Than Number of Training Sessions</label>
+        </rules>
+    </decisions>
+    <decisions>
+        <description>Checks the Record Type of the triggering Opportunity record</description>
+        <name>Check_Opportunity_Record_Type</name>
+        <label>Check Opportunity Record Type</label>
+        <locationX>1866</locationX>
+        <locationY>266</locationY>
+        <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>
+        <rules>
+            <name>Is_Advisory</name>
+            <conditionLogic>or</conditionLogic>
+            <conditions>
+                <leftValueReference>Get_Opportunity.RecordType.Name</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <elementReference>advisoryOpportunity</elementReference>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Assign_Advisory_Record_Type</targetReference>
+            </connector>
+            <label>Is Advisory</label>
+        </rules>
+        <rules>
+            <name>Is_Licensing</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>Get_Opportunity.RecordType.Name</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <elementReference>licensingOpportunity</elementReference>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Assign_Licensing_Record_Type</targetReference>
+            </connector>
+            <label>Is Licensing</label>
+        </rules>
+        <rules>
+            <name>Is_Training</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>Get_Opportunity.RecordType.Name</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <elementReference>trainingOpportunity</elementReference>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Check_Number_of_Trainings</targetReference>
+            </connector>
+            <label>Is Training</label>
+        </rules>
+    </decisions>
+    <description>Autolaunched flow to be triggered by a button on an Opportunity record to generate Deal Support Process(es)</description>
+    <environments>Default</environments>
+    <interviewLabel>Opportunity - Generate Deal Support Processes {!$Flow.CurrentDateTime}</interviewLabel>
+    <label>Opportunity - Generate Deal Support Processes</label>
+    <loops>
+        <description>Assigns the retrieved Deal Support Process record types to their respective variables</description>
+        <name>Assign_Record_Type_Ids_to_Variables</name>
+        <label>Assign Record Type Ids to Variables</label>
+        <locationX>1204</locationX>
+        <locationY>155</locationY>
+        <collectionReference>Get_Deal_Support_Process_Record_Types</collectionReference>
+        <iterationOrder>Asc</iterationOrder>
+        <nextValueConnector>
+            <targetReference>Check_Deal_Support_Process_Name</targetReference>
+        </nextValueConnector>
+        <noMoreValuesConnector>
+            <targetReference>Iterate_through_Opportunity_Products</targetReference>
+        </noMoreValuesConnector>
+    </loops>
+    <loops>
+        <description>Iterates through the retrieved collection of Opportunity Products</description>
+        <name>Iterate_through_Opportunity_Products</name>
+        <label>Iterate through Opportunity Products</label>
+        <locationX>1641</locationX>
+        <locationY>157</locationY>
+        <collectionReference>Get_Opportunity_Products</collectionReference>
+        <iterationOrder>Asc</iterationOrder>
+        <nextValueConnector>
+            <targetReference>Check_Opportunity_Record_Type</targetReference>
+        </nextValueConnector>
+        <noMoreValuesConnector>
+            <targetReference>Create_Deal_Support_Processes</targetReference>
+        </noMoreValuesConnector>
+    </loops>
+    <processMetadataValues>
+        <name>BuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>CanvasMode</name>
+        <value>
+            <stringValue>FREE_FORM_CANVAS</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>OriginBuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processType>AutoLaunchedFlow</processType>
+    <recordCreates>
+        <description>Creates Deal Support Process records</description>
+        <name>Create_Deal_Support_Processes</name>
+        <label>Create Deal Support Processes</label>
+        <locationX>1445</locationX>
+        <locationY>706</locationY>
+        <connector>
+            <targetReference>Update_Opportunity</targetReference>
+        </connector>
+        <inputReference>dealSupportProcesses</inputReference>
+    </recordCreates>
+    <recordLookups>
+        <description>Retrieves the active Deal Support Process record types</description>
+        <name>Get_Deal_Support_Process_Record_Types</name>
+        <label>Get Deal Support Process Record Types</label>
+        <locationX>980</locationX>
+        <locationY>340</locationY>
+        <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
+        <connector>
+            <targetReference>Assign_Record_Type_Ids_to_Variables</targetReference>
+        </connector>
+        <filterLogic>1 AND (2 OR 3 OR 4)</filterLogic>
+        <filters>
+            <field>SobjectType</field>
+            <operator>EqualTo</operator>
+            <value>
+                <stringValue>Deal_Support_Process__c</stringValue>
+            </value>
+        </filters>
+        <filters>
+            <field>Name</field>
+            <operator>EqualTo</operator>
+            <value>
+                <elementReference>advisoryDSPName</elementReference>
+            </value>
+        </filters>
+        <filters>
+            <field>Name</field>
+            <operator>EqualTo</operator>
+            <value>
+                <elementReference>licensingDSPName</elementReference>
+            </value>
+        </filters>
+        <filters>
+            <field>Name</field>
+            <operator>EqualTo</operator>
+            <value>
+                <elementReference>trainingDSPName</elementReference>
+            </value>
+        </filters>
+        <getFirstRecordOnly>false</getFirstRecordOnly>
+        <object>RecordType</object>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordLookups>
+    <recordLookups>
+        <description>Retrieves triggering Opportunity record</description>
+        <name>Get_Opportunity</name>
+        <label>Get Opportunity</label>
+        <locationX>989</locationX>
+        <locationY>220</locationY>
+        <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
+        <connector>
+            <targetReference>Get_Deal_Support_Process_Record_Types</targetReference>
+        </connector>
+        <filterLogic>and</filterLogic>
+        <filters>
+            <field>Id</field>
+            <operator>EqualTo</operator>
+            <value>
+                <elementReference>opportunityId</elementReference>
+            </value>
+        </filters>
+        <getFirstRecordOnly>true</getFirstRecordOnly>
+        <object>Opportunity</object>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordLookups>
+    <recordLookups>
+        <description>Retrieves all active Opportunity Products related to a given Opportunity</description>
+        <name>Get_Opportunity_Products</name>
+        <label>Get Opportunity Products</label>
+        <locationX>990</locationX>
+        <locationY>81</locationY>
+        <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
+        <connector>
+            <targetReference>Get_Opportunity</targetReference>
+        </connector>
+        <filterLogic>and</filterLogic>
+        <filters>
+            <field>OpportunityId</field>
+            <operator>EqualTo</operator>
+            <value>
+                <elementReference>opportunityId</elementReference>
+            </value>
+        </filters>
+        <getFirstRecordOnly>false</getFirstRecordOnly>
+        <object>OpportunityLineItem</object>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordLookups>
+    <recordUpdates>
+        <description>Enables the Has Deal Support Process checkbox to denote that a record of that SObject type has been generated</description>
+        <name>Update_Opportunity</name>
+        <label>Update Opportunity</label>
+        <locationX>1446</locationX>
+        <locationY>875</locationY>
+        <filterLogic>and</filterLogic>
+        <filters>
+            <field>Id</field>
+            <operator>EqualTo</operator>
+            <value>
+                <elementReference>opportunityId</elementReference>
+            </value>
+        </filters>
+        <inputAssignments>
+            <field>Has_Deal_Support_Process__c</field>
+            <value>
+                <booleanValue>true</booleanValue>
+            </value>
+        </inputAssignments>
+        <object>Opportunity</object>
+    </recordUpdates>
+    <start>
+        <locationX>1130</locationX>
+        <locationY>48</locationY>
+        <connector>
+            <targetReference>Get_Opportunity_Products</targetReference>
+        </connector>
+    </start>
+    <status>Active</status>
+    <variables>
+        <description>Represents the Id for the Deal Support Process record type &quot;Advisory&quot;</description>
+        <name>advisoryDSPId</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+    </variables>
+    <variables>
+        <description>Text representation of the Deal Support Process Advisory record type name</description>
+        <name>advisoryDSPName</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+        <value>
+            <stringValue>Advisory</stringValue>
+        </value>
+    </variables>
+    <variables>
+        <description>Text representation of the Advisory Opportunity Record Type</description>
+        <name>advisoryOpportunity</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+        <value>
+            <stringValue>Advisory Services</stringValue>
+        </value>
+    </variables>
+    <variables>
+        <description>Contains a single Deal Support Process record</description>
+        <name>dealSupportProcess</name>
+        <dataType>SObject</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+        <objectType>Deal_Support_Process__c</objectType>
+    </variables>
+    <variables>
+        <description>Contains a collection of Deal Support Process records</description>
+        <name>dealSupportProcesses</name>
+        <dataType>SObject</dataType>
+        <isCollection>true</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+        <objectType>Deal_Support_Process__c</objectType>
+    </variables>
+    <variables>
+        <description>Variable to hold Deal Support Process record type Id</description>
+        <name>dspRecordType</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+    </variables>
+    <variables>
+        <description>Represents the Id for the Deal Support Process record type &quot;Licensing&quot;</description>
+        <name>licensingDSPId</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+    </variables>
+    <variables>
+        <description>Text representation of the Deal Support Process Licensing record type name</description>
+        <name>licensingDSPName</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+        <value>
+            <stringValue>Licensing</stringValue>
+        </value>
+    </variables>
+    <variables>
+        <description>Text representation of the Licensing Opportunity Record Type</description>
+        <name>licensingOpportunity</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+        <value>
+            <stringValue>Site Licensing</stringValue>
+        </value>
+    </variables>
+    <variables>
+        <description>Id of triggering Opportunity record</description>
+        <name>opportunityId</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>true</isInput>
+        <isOutput>false</isOutput>
+    </variables>
+    <variables>
+        <description>Iteration counter to count the number of Training sessions purchased</description>
+        <name>trainingCounter</name>
+        <dataType>Number</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+        <scale>0</scale>
+        <value>
+            <numberValue>0.0</numberValue>
+        </value>
+    </variables>
+    <variables>
+        <description>Represents the Id for the Deal Support Process record type &quot;Training&quot;</description>
+        <name>trainingDSPId</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+    </variables>
+    <variables>
+        <description>Text representation of the Deal Support Process Training record type name</description>
+        <name>trainingDSPName</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+        <value>
+            <stringValue>Training</stringValue>
+        </value>
+    </variables>
+    <variables>
+        <description>Text representation of the Training Record Type</description>
+        <name>trainingOpportunity</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+        <value>
+            <stringValue>Enterprise Training</stringValue>
+        </value>
+    </variables>
+</Flow>

--- a/force-app/main/default/flows/Opportunity_Generate_Deal_Support_Processes.flow-meta.xml
+++ b/force-app/main/default/flows/Opportunity_Generate_Deal_Support_Processes.flow-meta.xml
@@ -110,6 +110,27 @@
                 <elementReference>dspRecordType</elementReference>
             </value>
         </assignmentItems>
+        <assignmentItems>
+            <assignToReference>dealSupportProcess.AccountId__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>Iterate_through_Opportunity_Products.Opportunity.Account.Id</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>dealSupportProcess.Opportunity__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>opportunityId</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>dealSupportProcess.Program_Title__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>Iterate_through_Opportunity_Products.Opportunity.Program_Title__c</elementReference>
+            </value>
+        </assignmentItems>
         <connector>
             <targetReference>Add_Deal_Support_Process_Record_to_Collection</targetReference>
         </connector>
@@ -153,6 +174,27 @@
             <operator>Assign</operator>
             <value>
                 <elementReference>trainingDSPId</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>dealSupportProcess.AccountId__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>Iterate_through_Opportunity_Products.Opportunity.Account.Id</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>dealSupportProcess.Opportunity__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>opportunityId</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>dealSupportProcess.Program_Title__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>Iterate_through_Opportunity_Products.Opportunity.Program_Title__c</elementReference>
             </value>
         </assignmentItems>
         <connector>

--- a/force-app/main/default/objects/Opportunity/fields/Has_Deal_Support_Process__c.field-meta.xml
+++ b/force-app/main/default/objects/Opportunity/fields/Has_Deal_Support_Process__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Has_Deal_Support_Process__c</fullName>
+    <defaultValue>false</defaultValue>
+    <description>Boolean value that is enabled when a Deal Support Process that looks up to that parent Opportunity is generated.</description>
+    <externalId>false</externalId>
+    <label>Has Deal Support Process</label>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/objects/Opportunity/webLinks/Generate_Deal_Support_Process.webLink-meta.xml
+++ b/force-app/main/default/objects/Opportunity/webLinks/Generate_Deal_Support_Process.webLink-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<WebLink xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Generate_Deal_Support_Process</fullName>
+    <availability>online</availability>
+    <description>Generates Deal Support Process using Opportunity Products related to triggering parent Opportunity</description>
+    <displayType>button</displayType>
+    <encodingKey>UTF-8</encodingKey>
+    <linkType>url</linkType>
+    <masterLabel>Generate Deal Support Process</masterLabel>
+    <openType>replace</openType>
+    <protected>false</protected>
+    <url>/flow/Opportunity_Generate_Deal_Support_Processes?opportunityId={!Opportunity.Id}</url>
+</WebLink>

--- a/force-app/main/default/permissionsets/Global_Growth_Base_Permission_Set.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Global_Growth_Base_Permission_Set.permissionset-meta.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customPermissions>
+        <enabled>true</enabled>
+        <name>Generate_Deal_Support_Process_Permission</name>
+    </customPermissions>
     <fieldPermissions>
         <editable>true</editable>
         <field>APXT_Redlining__Contract_Agreement__c.Deal_Support_Process__c</field>
@@ -43,6 +47,11 @@
     <fieldPermissions>
         <editable>true</editable>
         <field>Deal_Support_Process__c.Agent_count__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Deal_Support_Process__c.Amount__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
@@ -221,6 +230,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>true</editable>
+        <field>Deal_Support_Process__c.Opportunity_Product__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>Deal_Support_Process__c.Opportunity_Record_Type__c</field>
         <readable>true</readable>
@@ -257,12 +271,22 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Deal_Support_Process__c.Price__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Deal_Support_Process__c.Program_Requested_timeframe__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
         <field>Deal_Support_Process__c.Program_Title__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Deal_Support_Process__c.Quantity__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
@@ -373,6 +397,11 @@
     <fieldPermissions>
         <editable>true</editable>
         <field>Lead.Queue_Family__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Opportunity.Has_Deal_Support_Process__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>


### PR DESCRIPTION
* Creates flow to Generate Deal Support Process from an Opportunity
* Creates new Has_Deal_Support_Process__c checkbox field to denote if an Opportunity already parents one or more DSPs
* Creates custom permission to grant access to new custom button
* Updates Global Growth perm set to grant FLS access to new checkbox field
* Adds a custom button to the Opportunity object to trigger Generate Deal Support Process flow to the two main Opportunity lightning record pages