### PR TITLE
Feature/st00022 data consent

### DIFF
--- a/deployment/ST00022-Data-Consent/package.xml
+++ b/deployment/ST00022-Data-Consent/package.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+	<types>
+		<members>APXT_Redlining__Contract_Agreement__c.Data_Storage_Requirements__c</members>
+		<members>Account.Data_Storage_Requirements__c</members>
+		<name>CustomField</name>
+	</types>
+	<types>
+		<members>Account_Record_Page_Single_Related_Lists</members>
+		<members>ContractAgreementDynamic</members>
+		<name>FlexiPage</name>
+	</types>
+	<types>
+		<members>Contract_Agreement_Update_Field_on_other_Object_Flow_DSP</members>
+		<name>Flow</name>
+	</types>
+	<types>
+		<members>Data_Storage_Requirements</members>
+		<name>GlobalValueSet</name>
+	</types>
+	<types>
+		<members>Account-Prosci All Fields Lightning</members>
+		<name>Layout</name>
+	</types>
+	<types>
+		<members>Global_Growth_Base_Permission_Set</members>
+		<name>PermissionSet</name>
+	</types>
+	<version>60.0</version>
+</Package>

--- a/deployment/ST00022-Data-Consent/steps.md
+++ b/deployment/ST00022-Data-Consent/steps.md
@@ -1,0 +1,1 @@
+Activate updated flow in prod Contract Agreement - Update Field on other Object Flow DSP 

--- a/force-app/main/default/flexipages/Account_Record_Page_Single_Related_Lists.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Account_Record_Page_Single_Related_Lists.flexipage-meta.xml
@@ -31,6 +31,27 @@
         <type>Region</type>
     </flexiPageRegions>
     <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>decorate</name>
+                    <value>true</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>richTextValue</name>
+                    <value>&lt;h3 style=&quot;text-align: center;&quot;&gt;&lt;strong style=&quot;font-family: &amp;quot;Inter var&amp;quot;, Arial, Helvetica, sans-serif, &amp;quot;Segoe UI Emoji&amp;quot;, &amp;quot;Segoe UI Symbol&amp;quot;; color: rgb(255, 47, 0);&quot;&gt;This company does &lt;u&gt;NOT&lt;/u&gt; consent to store their data in Prosci&apos;s systems.&lt;/strong&gt;&lt;/h3&gt;</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:richText</componentName>
+                <identifier>flexipage_richText</identifier>
+                <visibilityRule>
+                    <criteria>
+                        <leftValue>{!Record.Data_Storage_Requirements__c}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>Does Not Consent</rightValue>
+                    </criteria>
+                </visibilityRule>
+            </componentInstance>
+        </itemInstances>
         <name>subheader</name>
         <type>Region</type>
     </flexiPageRegions>

--- a/force-app/main/default/flexipages/ContractAgreementDynamic.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/ContractAgreementDynamic.flexipage-meta.xml
@@ -235,6 +235,23 @@
                 <identifier>RecordDate_Time_Returned_from_Client_Review_cField</identifier>
             </fieldInstance>
         </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.Data_Storage_Requirements__c</fieldItem>
+                <identifier>RecordData_Storage_Requirements__cField</identifier>
+                <visibilityRule>
+                    <criteria>
+                        <leftValue>{!Record.APXT_Redlining__Type__c}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>Professional Services Agreement</rightValue>
+                    </criteria>
+                </visibilityRule>
+            </fieldInstance>
+        </itemInstances>
         <name>Facet-abd4d196-9bf0-45ac-8797-f578652e8e89</name>
         <type>Facet</type>
     </flexiPageRegions>

--- a/force-app/main/default/flows/Contract_Agreement_Update_Field_on_other_Object_Flow_DSP.flow-meta.xml
+++ b/force-app/main/default/flows/Contract_Agreement_Update_Field_on_other_Object_Flow_DSP.flow-meta.xml
@@ -4,7 +4,7 @@
         <name>Send_License_Confirmation_Email</name>
         <label>Send License Confirmation Email</label>
         <locationX>1370</locationX>
-        <locationY>1163</locationY>
+        <locationY>1463</locationY>
         <actionName>Opportunity.License_Confirmations</actionName>
         <actionType>emailAlert</actionType>
         <connector>
@@ -24,7 +24,7 @@
         <name>Send_Secondary_License_Confirmation_Email</name>
         <label>Send Secondary License Confirmation Email</label>
         <locationX>446</locationX>
-        <locationY>1163</locationY>
+        <locationY>1463</locationY>
         <actionName>Opportunity.License_Confirmations</actionName>
         <actionType>emailAlert</actionType>
         <connector>
@@ -45,7 +45,7 @@
         <name>Inactive_Is_this_a_primary_or_secondary_license</name>
         <label>Inactive - Is this a primary or secondary license?</label>
         <locationX>2822</locationX>
-        <locationY>539</locationY>
+        <locationY>839</locationY>
         <defaultConnector>
             <targetReference>Update_Account_on_Marked_Inactive</targetReference>
         </defaultConnector>
@@ -70,7 +70,7 @@
         <name>Is_secondary_license_elearning</name>
         <label>Is secondary license elearning?</label>
         <locationX>446</locationX>
-        <locationY>1271</locationY>
+        <locationY>1571</locationY>
         <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>
         <rules>
             <name>Yes_elearning</name>
@@ -92,7 +92,7 @@
         <name>Is_this_a_primary_or_secondary_license</name>
         <label>Is this a primary or secondary license?</label>
         <locationX>908</locationX>
-        <locationY>947</locationY>
+        <locationY>1247</locationY>
         <defaultConnector>
             <targetReference>Update_Account_Primary_License</targetReference>
         </defaultConnector>
@@ -117,7 +117,7 @@
         <name>Termination_Type_of_Contract</name>
         <label>Termination Type of Contract</label>
         <locationX>3482</locationX>
-        <locationY>431</locationY>
+        <locationY>731</locationY>
         <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>
         <rules>
             <name>Terminate_PSA</name>
@@ -154,7 +154,7 @@
         <name>Type_of_Contract</name>
         <label>Type of Contract</label>
         <locationX>1238</locationX>
-        <locationY>839</locationY>
+        <locationY>1139</locationY>
         <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>
         <rules>
             <name>PSA</name>
@@ -206,7 +206,7 @@
         <name>Update_Single_or_Multiple_DSPs</name>
         <label>Update Single or Multiple DSPs?</label>
         <locationX>1238</locationX>
-        <locationY>539</locationY>
+        <locationY>839</locationY>
         <defaultConnector>
             <targetReference>Update_Deal_Support_Process</targetReference>
         </defaultConnector>
@@ -235,10 +235,43 @@
         </rules>
     </decisions>
     <decisions>
+        <description>Updates the related account if it is set to Does Not Consent</description>
+        <name>Was_Data_Storage_Requirements_Set</name>
+        <label>Was Data Storage Requirements Set?</label>
+        <locationX>2756</locationX>
+        <locationY>323</locationY>
+        <defaultConnector>
+            <targetReference>Was_the_Status_Updated</targetReference>
+        </defaultConnector>
+        <defaultConnectorLabel>None</defaultConnectorLabel>
+        <rules>
+            <name>Does_Not_Consent</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>$Record.Data_Storage_Requirements__c</leftValueReference>
+                <operator>IsChanged</operator>
+                <rightValue>
+                    <booleanValue>true</booleanValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>$Record.Data_Storage_Requirements__c</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>Does Not Consent</stringValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Update_Account_Data_Storage_Requirements</targetReference>
+            </connector>
+            <label>Does Not Consent</label>
+        </rules>
+    </decisions>
+    <decisions>
         <name>Was_the_Status_Updated</name>
         <label>Was the Status Updated?</label>
         <locationX>2756</locationX>
-        <locationY>323</locationY>
+        <locationY>623</locationY>
         <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>
         <rules>
             <name>Active</name>
@@ -316,7 +349,7 @@
         <name>What_Type_of_license</name>
         <label>What Type of license?</label>
         <locationX>1370</locationX>
-        <locationY>1271</locationY>
+        <locationY>1571</locationY>
         <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>
         <rules>
             <name>ADKAR</name>
@@ -416,7 +449,7 @@
         <name>Update_Account</name>
         <label>Update Account</label>
         <locationX>3482</locationX>
-        <locationY>539</locationY>
+        <locationY>839</locationY>
         <inputAssignments>
             <field>Active_License_Status__c</field>
             <value>
@@ -426,10 +459,27 @@
         <inputReference>$Record.APXT_Redlining__Account__r</inputReference>
     </recordUpdates>
     <recordUpdates>
+        <description>Update related account value to match Contract Agreement</description>
+        <name>Update_Account_Data_Storage_Requirements</name>
+        <label>Update Account Data Storage Requirements</label>
+        <locationX>2624</locationX>
+        <locationY>431</locationY>
+        <connector>
+            <targetReference>Was_the_Status_Updated</targetReference>
+        </connector>
+        <inputAssignments>
+            <field>Data_Storage_Requirements__c</field>
+            <value>
+                <stringValue>Does Not Consent</stringValue>
+            </value>
+        </inputAssignments>
+        <inputReference>$Record.APXT_Redlining__Account__r</inputReference>
+    </recordUpdates>
+    <recordUpdates>
         <name>Update_Account_for_PSA</name>
         <label>Update Account for PSA</label>
         <locationX>50</locationX>
-        <locationY>947</locationY>
+        <locationY>1247</locationY>
         <filterLogic>and</filterLogic>
         <filters>
             <field>Id</field>
@@ -468,7 +518,7 @@
         <name>Update_Account_on_Marked_Inactive</name>
         <label>Update Account on Marked Inactive</label>
         <locationX>2954</locationX>
-        <locationY>647</locationY>
+        <locationY>947</locationY>
         <filterLogic>and</filterLogic>
         <filters>
             <field>Id</field>
@@ -495,7 +545,7 @@
         <name>Update_Account_on_Marked_Inactive_Secondary</name>
         <label>Update Account on Marked Inactive Secondary</label>
         <locationX>2690</locationX>
-        <locationY>647</locationY>
+        <locationY>947</locationY>
         <filterLogic>and</filterLogic>
         <filters>
             <field>Id</field>
@@ -516,7 +566,7 @@
         <name>Update_Account_Primary_License</name>
         <label>Update Account Primary License</label>
         <locationX>1370</locationX>
-        <locationY>1055</locationY>
+        <locationY>1355</locationY>
         <connector>
             <targetReference>Send_License_Confirmation_Email</targetReference>
         </connector>
@@ -564,7 +614,7 @@
         <name>Update_Account_PSA_Expiration_Date</name>
         <label>Update Account PSA Expiration Date</label>
         <locationX>3218</locationX>
-        <locationY>539</locationY>
+        <locationY>839</locationY>
         <inputAssignments>
             <field>PSA_Expiration_Date__c</field>
             <value>
@@ -577,7 +627,7 @@
         <name>Update_Account_Secondary_License</name>
         <label>Update Account Secondary License</label>
         <locationX>446</locationX>
-        <locationY>1055</locationY>
+        <locationY>1355</locationY>
         <connector>
             <targetReference>Send_Secondary_License_Confirmation_Email</targetReference>
         </connector>
@@ -613,7 +663,7 @@
         <name>Update_ADKAR_price_group</name>
         <label>Update ADKAR price group</label>
         <locationX>842</locationX>
-        <locationY>1379</locationY>
+        <locationY>1679</locationY>
         <filterLogic>and</filterLogic>
         <filters>
             <field>Id</field>
@@ -634,7 +684,7 @@
         <name>Update_Contract_Agreement</name>
         <label>Update Contract Agreement</label>
         <locationX>1238</locationX>
-        <locationY>431</locationY>
+        <locationY>731</locationY>
         <connector>
             <targetReference>Update_Single_or_Multiple_DSPs</targetReference>
         </connector>
@@ -650,7 +700,7 @@
         <name>Update_Contract_Agreement_on_Marked_Inactive</name>
         <label>Update Contract Agreement on Marked Inactive</label>
         <locationX>2822</locationX>
-        <locationY>431</locationY>
+        <locationY>731</locationY>
         <connector>
             <targetReference>Inactive_Is_this_a_primary_or_secondary_license</targetReference>
         </connector>
@@ -666,7 +716,7 @@
         <name>Update_Contract_Agreement_with_Expiration</name>
         <label>Update Contract Agreement with Expiration</label>
         <locationX>2162</locationX>
-        <locationY>947</locationY>
+        <locationY>1247</locationY>
         <inputAssignments>
             <field>APXT_Redlining__Expiration_Date__c</field>
             <value>
@@ -680,7 +730,7 @@
         <name>Update_Deal_Support_Process</name>
         <label>Update Deal Support Process</label>
         <locationX>1370</locationX>
-        <locationY>647</locationY>
+        <locationY>947</locationY>
         <connector>
             <targetReference>Type_of_Contract</targetReference>
         </connector>
@@ -704,7 +754,7 @@
         <name>Update_ECM_price_group</name>
         <label>Update ECM price group</label>
         <locationX>1370</locationX>
-        <locationY>1379</locationY>
+        <locationY>1679</locationY>
         <filterLogic>and</filterLogic>
         <filters>
             <field>Id</field>
@@ -725,7 +775,7 @@
         <name>Update_Elearning_License</name>
         <label>Update Elearning License</label>
         <locationX>1634</locationX>
-        <locationY>1379</locationY>
+        <locationY>1679</locationY>
         <filterLogic>and</filterLogic>
         <filters>
             <field>Id</field>
@@ -746,7 +796,7 @@
         <name>Update_elearning_on_secondary_license</name>
         <label>Update elearning on secondary license</label>
         <locationX>314</locationX>
-        <locationY>1379</locationY>
+        <locationY>1679</locationY>
         <filterLogic>and</filterLogic>
         <filters>
             <field>Id</field>
@@ -768,7 +818,7 @@
         <name>Update_Multiple_DSP_Records</name>
         <label>Update Multiple DSP Records</label>
         <locationX>1106</locationX>
-        <locationY>647</locationY>
+        <locationY>947</locationY>
         <connector>
             <targetReference>Type_of_Contract</targetReference>
         </connector>
@@ -813,7 +863,7 @@
         <name>Update_OCC_price_group</name>
         <label>Update OCC price group</label>
         <locationX>1106</locationX>
-        <locationY>1379</locationY>
+        <locationY>1679</locationY>
         <filterLogic>and</filterLogic>
         <filters>
             <field>Id</field>
@@ -834,7 +884,7 @@
         <locationX>2630</locationX>
         <locationY>0</locationY>
         <connector>
-            <targetReference>Was_the_Status_Updated</targetReference>
+            <targetReference>Was_Data_Storage_Requirements_Set</targetReference>
         </connector>
         <object>APXT_Redlining__Contract_Agreement__c</object>
         <recordTriggerType>CreateAndUpdate</recordTriggerType>

--- a/force-app/main/default/globalValueSets/Data_Storage_Requirements.globalValueSet-meta.xml
+++ b/force-app/main/default/globalValueSets/Data_Storage_Requirements.globalValueSet-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GlobalValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customValue>
+        <fullName>None</fullName>
+        <default>true</default>
+        <label>None</label>
+    </customValue>
+    <customValue>
+        <fullName>Does Not Consent</fullName>
+        <default>false</default>
+        <label>Does Not Consent</label>
+    </customValue>
+    <description>Used by the picklist on Account and Contract Agreement objects</description>
+    <masterLabel>Data Storage Requirements</masterLabel>
+    <sorted>false</sorted>
+</GlobalValueSet>

--- a/force-app/main/default/layouts/Account-Prosci All Fields Lightning.layout-meta.xml
+++ b/force-app/main/default/layouts/Account-Prosci All Fields Lightning.layout-meta.xml
@@ -3,6 +3,9 @@
     <customButtons>Training_Summary</customButtons>
     <customButtons>MA_MapIt_a0vi000000Bnnt5AAB</customButtons>
     <customButtons>Add_Document</customButtons>
+    <excludeButtons>DataDotComAccountInsights</excludeButtons>
+    <excludeButtons>DataDotComClean</excludeButtons>
+    <excludeButtons>DataDotComCompanyHierarchy</excludeButtons>
     <excludeButtons>DisableCustomerPortalAccount</excludeButtons>
     <excludeButtons>DisablePartnerPortalAccount</excludeButtons>
     <excludeButtons>IncludeOffline</excludeButtons>
@@ -98,6 +101,10 @@
             <layoutItems>
                 <behavior>Edit</behavior>
                 <field>Don_t_Assign_Prework_Proxima__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Readonly</behavior>
+                <field>Data_Storage_Requirements__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsTopToBottom</style>
@@ -316,6 +323,14 @@
                 <behavior>Edit</behavior>
                 <field>Licensed_Materials_Version__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Secondary_License_Active_License_Status__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Secondary_License_Active_License_Type__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
@@ -328,7 +343,19 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
+                <field>Can_we_use_PO_number_on_Invoice__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
                 <field>Registration_Slug__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Secondary_License_elearning__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Secondary_License_License__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -348,12 +375,7 @@
                 <field>PSA_Expiration_Date__c</field>
             </layoutItems>
         </layoutColumns>
-        <layoutColumns>
-            <layoutItems>
-                <behavior>Edit</behavior>
-                <field>Can_we_use_PO_number_on_Invoice__c</field>
-            </layoutItems>
-        </layoutColumns>
+        <layoutColumns/>
         <style>TwoColumnsLeftToRight</style>
     </layoutSections>
     <layoutSections>
@@ -368,7 +390,11 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>EORI_or_other_Shipping_Info__c</field>
+                <field>Customs_Shipping_Number__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Shipping_Notes__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
@@ -837,6 +863,18 @@
         <relatedList>RelatedContractList</relatedList>
     </relatedLists>
     <relatedLists>
+        <fields>NAME</fields>
+        <fields>Affiliate_Company__c</fields>
+        <fields>Covered_Contract_Type__c</fields>
+        <relatedList>Affiliates_Covered_under_License__c.Licensed_Account__c</relatedList>
+    </relatedLists>
+    <relatedLists>
+        <fields>NAME</fields>
+        <fields>Licensed_Account__c</fields>
+        <fields>Covered_Contract_Type__c</fields>
+        <relatedList>Affiliates_Covered_under_License__c.Affiliate_Company__c</relatedList>
+    </relatedLists>
+    <relatedLists>
         <relatedList>RelatedEntityHistoryList</relatedList>
     </relatedLists>
     <relatedLists>
@@ -856,8 +894,9 @@
     <relatedLists>
         <fields>NAME</fields>
         <fields>APXT_Redlining__Type__c</fields>
-        <fields>APXT_Redlining__Status__c</fields>
+        <fields>Requested_Start_Date_Opportunity__c</fields>
         <fields>Program_Title__c</fields>
+        <fields>APXT_Redlining__Status__c</fields>
         <fields>APXT_Redlining__Effective_Date__c</fields>
         <fields>APXT_Redlining__Expiration_Date__c</fields>
         <fields>CREATED_DATE</fields>

--- a/force-app/main/default/objects/APXT_Redlining__Contract_Agreement__c/fields/Data_Storage_Requirements__c.field-meta.xml
+++ b/force-app/main/default/objects/APXT_Redlining__Contract_Agreement__c/fields/Data_Storage_Requirements__c.field-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Data_Storage_Requirements__c</fullName>
+    <description>Setting this to Does Not Consent will trigger the flow &quot;Contract Agreement - Update Field on other Object Flow DSP&quot; to update the same field on the related Account to Does Not Consent</description>
+    <externalId>false</externalId>
+    <label>Data Storage Requirements</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetName>Data_Storage_Requirements</valueSetName>
+    </valueSet>
+</CustomField>

--- a/force-app/main/default/objects/Account/fields/Data_Storage_Requirements__c.field-meta.xml
+++ b/force-app/main/default/objects/Account/fields/Data_Storage_Requirements__c.field-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Data_Storage_Requirements__c</fullName>
+    <description>Governs whether or not the page layout shows the warning about storing data in Salesforce</description>
+    <externalId>false</externalId>
+    <label>Data Storage Requirements</label>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetName>Data_Storage_Requirements</valueSetName>
+    </valueSet>
+</CustomField>

--- a/force-app/main/default/permissionsets/Global_Growth_Base_Permission_Set.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Global_Growth_Base_Permission_Set.permissionset-meta.xml
@@ -6,7 +6,17 @@
     </customPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>APXT_Redlining__Contract_Agreement__c.Data_Storage_Requirements__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>APXT_Redlining__Contract_Agreement__c.Deal_Support_Process__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Account.Data_Storage_Requirements__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>


### PR DESCRIPTION
- Adds Data Storage Consent fields on Account/Contract Agreement that use global value set
- Field is read only on Account page layout
- Field is editable on Contract Agreement but only renders when type is PSA
- Updates global permission set
- Updates flow to set Account to Does Not Consent if CA is set to Does Not Consent