### PR TITLE
ST00011-Opp-Closed-Reason-2

### DIFF
--- a/deployment/ST00011-Opp-Closed-Reason/package.xml
+++ b/deployment/ST00011-Opp-Closed-Reason/package.xml
@@ -7,7 +7,16 @@
 	</types>
 	<types>
 		<members>Opportunity.Closed_Reason__c</members>
+		<members>Opportunity.Closed_Reason_Blank__c</members>
 		<name>CustomField</name>
+	</types>
+	<types>
+		<members>Opportunity_Record_Page_Single_Related_Lists</members>
+		<name>FlexiPage</name>
+	</types>
+	<types>
+		<members>Global_Growth_Base_Permission_Set</members>
+		<name>PermissionSet</name>
 	</types>
 	<types>
 		<members>Opportunity.Closed_Reason_Required</members>

--- a/force-app/main/default/flexipages/Opportunity_Record_Page_Single_Related_Lists.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Opportunity_Record_Page_Single_Related_Lists.flexipage-meta.xml
@@ -102,6 +102,38 @@
         <itemInstances>
             <componentInstance>
                 <componentInstanceProperties>
+                    <name>decorate</name>
+                    <value>true</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>richTextValue</name>
+                    <value>&lt;h6 style=&quot;text-align: center;&quot;&gt;&lt;strong style=&quot;color: rgb(0, 118, 221);&quot;&gt;This Opportunity is Closed - Won but Closed Reason is missing&lt;/strong&gt;&lt;/h6&gt;&lt;h6 style=&quot;text-align: center;&quot;&gt;&lt;strong style=&quot;color: rgb(0, 118, 221);&quot;&gt;Please update field with the correct value&lt;/strong&gt;&lt;/h6&gt;</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:richText</componentName>
+                <identifier>flexipage_richText</identifier>
+                <visibilityRule>
+                    <booleanFilter>1 AND 2 AND 3</booleanFilter>
+                    <criteria>
+                        <leftValue>{!Record.RecordType.DeveloperName}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>Enterprise_Engagement</rightValue>
+                    </criteria>
+                    <criteria>
+                        <leftValue>{!Record.StageName}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>Closed - Won</rightValue>
+                    </criteria>
+                    <criteria>
+                        <leftValue>{!Record.Closed_Reason_Blank__c}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>true</rightValue>
+                    </criteria>
+                </visibilityRule>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
                     <name>hideUpdateButton</name>
                     <value>false</value>
                 </componentInstanceProperties>

--- a/force-app/main/default/objects/Opportunity/fields/Closed_Reason_Blank__c.field-meta.xml
+++ b/force-app/main/default/objects/Opportunity/fields/Closed_Reason_Blank__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Closed_Reason_Blank__c</fullName>
+    <description>Used by component visibility setting on the lightning page layout to show a warning when value is blank and the Opp is Closed - Won. Needed since we cannot check if picklist field is blank directly.</description>
+    <externalId>false</externalId>
+    <formula>ISBLANK(TEXT(Closed_Reason__c))</formula>
+    <label>Closed Reason Blank</label>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/permissionsets/Global_Growth_Base_Permission_Set.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Global_Growth_Base_Permission_Set.permissionset-meta.xml
@@ -440,6 +440,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>Opportunity.Closed_Reason_Blank__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>Opportunity.Closed_Reason__c</field>
         <readable>true</readable>


### PR DESCRIPTION
Adds a field to Opp called Close_Reason_Blank__c which checks if the Closed Reason is set, this is used by the page layout to render a notice that they should fill it out.

This is a workaround since you cannot have a picklist look for a blank value when using the component visibility filter for the rich text element.