### PR TITLE
Feature/st 00114 order config

### DIFF
--- a/deployment/st-00114-Order-Config/package.xml
+++ b/deployment/st-00114-Order-Config/package.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+	<types>
+		<members>Case_Schedule_Monthly_Exchange_Rate_Updates_for_Active_Currencies</members>
+		<name>Flow</name>
+	</types>
+	<version>60.0</version>
+</Package>

--- a/deployment/st-00114-Order-Config/steps.md
+++ b/deployment/st-00114-Order-Config/steps.md
@@ -1,0 +1,12 @@
+# Post-Deployment Steps:
+
+1. Grant EDIT access to System Administrator profile for the following fields:
+    * Order.Associated_Training_Contact__c
+    * Order.BillToContactId
+    * Order.ShipToContactId
+    * Order.Training_Event__c
+    
+    1. Setup -> Profiles -> System Administrator -> Object Settings -> Order
+    1. Click __Edit__ button upper center
+    1. Enable __EDIT__ access for each of the above fields
+    1. Click __Save__ 

--- a/force-app/main/default/flexipages/Order_Record_Page.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Order_Record_Page.flexipage-meta.xml
@@ -10,7 +10,7 @@
                             <value>Edit</value>
                         </valueListItems>
                         <valueListItems>
-                            <value>Order.Sync_to_Xero</value>
+                            <value>Order.Sync_to_ERP</value>
                             <visibilityRule>
                                 <criteria>
                                     <leftValue>{!Record.Target_Tenant_Id__c}</leftValue>
@@ -86,6 +86,26 @@
         <type>Region</type>
     </flexiPageRegions>
     <flexiPageRegions>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.Integration_Tenant__c</fieldItem>
+                <identifier>RecordIntegration_Tenant_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>readonly</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.Target_Tenant_Id__c</fieldItem>
+                <identifier>RecordTarget_Tenant_Id_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
         <itemInstances>
             <fieldInstance>
                 <fieldInstanceProperties>
@@ -166,30 +186,30 @@
                 <identifier>RecordBilling_Country_Code_cField</identifier>
             </fieldInstance>
         </itemInstances>
+        <name>Facet-4281a1dc-e764-4e4a-b3f7-d7a4a4763c25</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+    <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
                 <fieldInstanceProperties>
                     <name>uiBehavior</name>
                     <value>none</value>
                 </fieldInstanceProperties>
-                <fieldItem>Record.Integration_Tenant__c</fieldItem>
-                <identifier>RecordIntegration_Tenant_cField</identifier>
+                <fieldItem>Record.Associated_Training_Contact__c</fieldItem>
+                <identifier>RecordAssociated_Training_Contact_cField</identifier>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
             <fieldInstance>
                 <fieldInstanceProperties>
                     <name>uiBehavior</name>
-                    <value>readonly</value>
+                    <value>none</value>
                 </fieldInstanceProperties>
-                <fieldItem>Record.Target_Tenant_Id__c</fieldItem>
-                <identifier>RecordTarget_Tenant_Id_cField</identifier>
+                <fieldItem>Record.Training_Event__c</fieldItem>
+                <identifier>RecordTraining_Event_cField</identifier>
             </fieldInstance>
         </itemInstances>
-        <name>Facet-4281a1dc-e764-4e4a-b3f7-d7a4a4763c25</name>
-        <type>Facet</type>
-    </flexiPageRegions>
-    <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
                 <fieldInstanceProperties>
@@ -208,26 +228,6 @@
                 </fieldInstanceProperties>
                 <fieldItem>Record.TotalAmount</fieldItem>
                 <identifier>RecordTotalAmountField</identifier>
-            </fieldInstance>
-        </itemInstances>
-        <itemInstances>
-            <fieldInstance>
-                <fieldInstanceProperties>
-                    <name>uiBehavior</name>
-                    <value>none</value>
-                </fieldInstanceProperties>
-                <fieldItem>Record.Type</fieldItem>
-                <identifier>RecordTypeField</identifier>
-            </fieldInstance>
-        </itemInstances>
-        <itemInstances>
-            <fieldInstance>
-                <fieldInstanceProperties>
-                    <name>uiBehavior</name>
-                    <value>required</value>
-                </fieldInstanceProperties>
-                <fieldItem>Record.Status</fieldItem>
-                <identifier>RecordStatusField</identifier>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
@@ -278,6 +278,16 @@
                 </fieldInstanceProperties>
                 <fieldItem>Record.ActivatedById</fieldItem>
                 <identifier>RecordActivatedByIdField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>required</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.Status</fieldItem>
+                <identifier>RecordStatusField</identifier>
             </fieldInstance>
         </itemInstances>
         <name>Facet-198ee6f0-a675-4e3d-9a17-b4c47cedbac9</name>

--- a/force-app/main/default/flexipages/Training_Event_Record_Page.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Training_Event_Record_Page.flexipage-meta.xml
@@ -40,6 +40,87 @@
         <itemInstances>
             <componentInstance>
                 <componentInstanceProperties>
+                    <name>actionNames</name>
+                    <valueList>
+                        <valueListItems>
+                            <value>New</value>
+                        </valueListItems>
+                    </valueList>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>adminFilters</name>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>maxRecordsToDisplay</name>
+                    <value>10</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>parentFieldApiName</name>
+                    <value>Training_Event__c.Id</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>relatedListApiName</name>
+                    <value>Orders__r</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>relatedListDisplayType</name>
+                    <value>ADVGRID</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>relatedListFieldAliases</name>
+                    <valueList>
+                        <valueListItems>
+                            <value>ORDERS.ORDER_NUMBER</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>SALES.ACCOUNT.NAME</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>ORDERS.STATUS</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>ORDERS.TOTAL_AMOUNT</value>
+                        </valueListItems>
+                    </valueList>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>relatedListLabel</name>
+                    <value>Orders</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>showActionBar</name>
+                    <value>true</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>sortFieldAlias</name>
+                    <value>__DEFAULT__</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>sortFieldOrder</name>
+                    <value>Default</value>
+                </componentInstanceProperties>
+                <componentName>lst:dynamicRelatedList</componentName>
+                <identifier>lst_dynamicRelatedList2</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>actionNames</name>
+                    <valueList>
+                        <valueListItems>
+                            <value>MassChangeOwner</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>New</value>
+                        </valueListItems>
+                    </valueList>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>maxRecordsToDisplay</name>
+                    <value>10</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
                     <name>parentFieldApiName</name>
                     <value>Training_Event__c.Id</value>
                 </componentInstanceProperties>
@@ -48,19 +129,35 @@
                     <value>Consulting_Time_Trackers__r</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
-                    <name>relatedListComponentOverride</name>
-                    <value>NONE</value>
+                    <name>relatedListDisplayType</name>
+                    <value>ADVGRID</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
-                    <name>rowsToDisplay</name>
-                    <value>10</value>
+                    <name>relatedListFieldAliases</name>
+                    <valueList>
+                        <valueListItems>
+                            <value>NAME</value>
+                        </valueListItems>
+                    </valueList>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>relatedListLabel</name>
+                    <value>Consulting Time Trackers</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>showActionBar</name>
                     <value>true</value>
                 </componentInstanceProperties>
-                <componentName>force:relatedListSingleContainer</componentName>
-                <identifier>force_relatedListSingleContainer11</identifier>
+                <componentInstanceProperties>
+                    <name>sortFieldAlias</name>
+                    <value>__DEFAULT__</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>sortFieldOrder</name>
+                    <value>Default</value>
+                </componentInstanceProperties>
+                <componentName>lst:dynamicRelatedList</componentName>
+                <identifier>lst_dynamicRelatedList</identifier>
             </componentInstance>
         </itemInstances>
         <itemInstances>

--- a/force-app/main/default/flows/Opportunity_Create_Order_from_Magento_created_Product_Order_Opp.flow-meta.xml
+++ b/force-app/main/default/flows/Opportunity_Create_Order_from_Magento_created_Product_Order_Opp.flow-meta.xml
@@ -388,6 +388,20 @@
                     <elementReference>$Record.Bill_To_Contact__c</elementReference>
                 </value>
             </transformValueActions>
+            <transformValueActions>
+                <outputFieldApiName>Training_Event__c</outputFieldApiName>
+                <transformType>Map</transformType>
+                <value>
+                    <elementReference>$Record.Training_Event__c</elementReference>
+                </value>
+            </transformValueActions>
+            <transformValueActions>
+                <outputFieldApiName>Associated_Training_Contact__c</outputFieldApiName>
+                <transformType>Map</transformType>
+                <value>
+                    <elementReference>$Record.Associated_Training_Contact__c</elementReference>
+                </value>
+            </transformValueActions>
         </transformValues>
     </transforms>
 </Flow>

--- a/force-app/main/default/flows/Order_Before_Create_Training_Event_VILT_Sync.flow-meta.xml
+++ b/force-app/main/default/flows/Order_Before_Create_Training_Event_VILT_Sync.flow-meta.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Flow xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <description>A before create flow that syncs the triggering Order&apos;s VILT field with that of its parent Training Event.</description>
+    <environments>Default</environments>
+    <interviewLabel>Order - Before Create Training Event VILT Sync {!$Flow.CurrentDateTime}</interviewLabel>
+    <label>Order - Before Create Training Event VILT Sync</label>
+    <processMetadataValues>
+        <name>BuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>CanvasMode</name>
+        <value>
+            <stringValue>AUTO_LAYOUT_CANVAS</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>OriginBuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processType>AutoLaunchedFlow</processType>
+    <recordLookups>
+        <description>Retrieves parent Training Event for the triggering Order</description>
+        <name>Get_Training_Event</name>
+        <label>Get Training Event</label>
+        <locationX>176</locationX>
+        <locationY>287</locationY>
+        <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
+        <connector>
+            <targetReference>UpdateOrder</targetReference>
+        </connector>
+        <filterLogic>and</filterLogic>
+        <filters>
+            <field>Id</field>
+            <operator>EqualTo</operator>
+            <value>
+                <elementReference>$Record.Training_Event__c</elementReference>
+            </value>
+        </filters>
+        <getFirstRecordOnly>true</getFirstRecordOnly>
+        <object>Training_Event__c</object>
+        <queriedFields>Id</queriedFields>
+        <queriedFields>VILT_Program__c</queriedFields>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordLookups>
+    <recordUpdates>
+        <description>Updates triggering Order with values retrieved from parent Training Event</description>
+        <name>UpdateOrder</name>
+        <label>Update Order</label>
+        <locationX>176</locationX>
+        <locationY>395</locationY>
+        <inputAssignments>
+            <field>VILT__c</field>
+            <value>
+                <elementReference>Get_Training_Event.VILT_Program__c</elementReference>
+            </value>
+        </inputAssignments>
+        <inputReference>$Record</inputReference>
+    </recordUpdates>
+    <start>
+        <locationX>50</locationX>
+        <locationY>0</locationY>
+        <connector>
+            <targetReference>Get_Training_Event</targetReference>
+        </connector>
+        <object>Order</object>
+        <recordTriggerType>Create</recordTriggerType>
+        <triggerType>RecordBeforeSave</triggerType>
+    </start>
+    <status>Active</status>
+</Flow>

--- a/force-app/main/default/objects/Order/fields/Associated_Training_Contact__c.field-meta.xml
+++ b/force-app/main/default/objects/Order/fields/Associated_Training_Contact__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Associated_Training_Contact__c</fullName>
+    <deleteConstraint>SetNull</deleteConstraint>
+    <externalId>false</externalId>
+    <label>Associated Training Contact</label>
+    <referenceTo>Contact</referenceTo>
+    <relationshipLabel>Orders (Associated Training Contact)</relationshipLabel>
+    <relationshipName>Orders2</relationshipName>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <type>Lookup</type>
+</CustomField>

--- a/force-app/main/default/objects/Order/fields/Training_Event__c.field-meta.xml
+++ b/force-app/main/default/objects/Order/fields/Training_Event__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Training_Event__c</fullName>
+    <deleteConstraint>SetNull</deleteConstraint>
+    <description>Lookup to related Training Event</description>
+    <externalId>false</externalId>
+    <label>Training Event</label>
+    <referenceTo>Training_Event__c</referenceTo>
+    <relationshipLabel>Orders</relationshipLabel>
+    <relationshipName>Orders</relationshipName>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <type>Lookup</type>
+</CustomField>

--- a/force-app/main/default/permissionsets/Global_Growth_Base_Permission_Set.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Global_Growth_Base_Permission_Set.permissionset-meta.xml
@@ -546,6 +546,16 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Order.Associated_Training_Contact__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Order.BillToContactId</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Order.Billing_Country_Code__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -562,6 +572,11 @@
     <fieldPermissions>
         <editable>true</editable>
         <field>Order.Payment_Type__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Order.ShipToContactId</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/force-app/main/default/quickActions/Order.Sync_to_ERP.quickAction-meta.xml
+++ b/force-app/main/default/quickActions/Order.Sync_to_ERP.quickAction-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<QuickAction xmlns="http://soap.sforce.com/2006/04/metadata">
+    <flowDefinition>Order_Create_OrderSync_for_Sync_to_Xero</flowDefinition>
+    <label>Sync to ERP</label>
+    <optionsCreateFeedItem>false</optionsCreateFeedItem>
+    <type>Flow</type>
+</QuickAction>


### PR DESCRIPTION
* Creates Training Event and Associated Training Contact lookup fields on Order
* Adds new fields to Order flexipage, re-orders Overview section
* Grants Global Growth and System Admin users access to the [Bill To] [Ship To] [Associated Training] Contact and Training Event lookup fields on Order
* Adds Orders related list to Training Event flexipage
* Updates label/name for "Sync to Xero" button to "Sync to ERP"
* Updates "Opportunity - Create Order from Magento-created Product Order Opp" flow, adds map assignments for Contact lookups on from Opp to Order
* Creates "Order Before Create Training Event VILT Sync" to sync VILT on Order with that of its parent Training Event