### PR TITLE
Feature/st 00114 order config

### DIFF
--- a/force-app/main/default/flows/Order_Before_Create_Training_Event_VILT_Sync.flow-meta.xml
+++ b/force-app/main/default/flows/Order_Before_Create_Training_Event_VILT_Sync.flow-meta.xml
@@ -68,6 +68,14 @@
         <connector>
             <targetReference>Get_Training_Event</targetReference>
         </connector>
+        <filterLogic>and</filterLogic>
+        <filters>
+            <field>Training_Event__c</field>
+            <operator>IsNull</operator>
+            <value>
+                <booleanValue>false</booleanValue>
+            </value>
+        </filters>
         <object>Order</object>
         <recordTriggerType>Create</recordTriggerType>
         <triggerType>RecordBeforeSave</triggerType>


### PR DESCRIPTION
* Adds entry criteria Order - Before Create Training Event VILT Sync flow to ensure it only runs if there's a Training Event associated with the triggering Order